### PR TITLE
アクセス制御

### DIFF
--- a/app/controllers/admin/base.rb
+++ b/app/controllers/admin/base.rb
@@ -1,4 +1,6 @@
 class Admin::Base < ApplicationController
+  before_action :authorize
+
   private def current_administrator
     if session[:administrator_id]
       @current_administrator ||=
@@ -7,4 +9,11 @@ class Admin::Base < ApplicationController
   end
 
   helper_method :current_administrator
+
+  private def authorize
+    unless current_administrator
+      flash.alert = "管理者としてログインしてください。"
+      redirect_to :admin_login
+    end
+  end
 end

--- a/app/controllers/admin/base.rb
+++ b/app/controllers/admin/base.rb
@@ -1,5 +1,6 @@
 class Admin::Base < ApplicationController
   before_action :authorize
+  before_action :check_account
 
   private def current_administrator
     if session[:administrator_id]
@@ -9,11 +10,21 @@ class Admin::Base < ApplicationController
   end
 
   helper_method :current_administrator
-
+  
+  # アクセス制御
   private def authorize
     unless current_administrator
       flash.alert = "管理者としてログインしてください。"
       redirect_to :admin_login
+    end
+  end
+
+  # 強制ログアウト
+  private def check_account
+    if current_administrator && !current_administrator.active?
+      session.delete(:staff_member_id)
+      flash.alert = "アカウントが無効になりました。"
+      redirect_to :admin_root
     end
   end
 end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -22,6 +22,7 @@ class Admin::SessionsController < Admin::Base
         render action: "new"
       else
         session[:administrator_id] = administrator.id
+        session[:last_access_time] = Time.current
         flash.notice = "ログインしました。"
         redirect_to :admin_root
       end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,4 +1,6 @@
 class Admin::SessionsController < Admin::Base
+  skip_before_action :authorize
+  
   def new
     if current_administrator
       redirect_to :admin_root

--- a/app/controllers/admin/top_controller.rb
+++ b/app/controllers/admin/top_controller.rb
@@ -1,4 +1,6 @@
 class Admin::TopController < Admin::Base
+  skip_before_action :authorize
+  
   def index
     if current_administrator
       render action: "dashboard"

--- a/app/controllers/staff/base.rb
+++ b/app/controllers/staff/base.rb
@@ -1,4 +1,6 @@
 class Staff::Base < ApplicationController
+  before_action :authorize
+
   private def current_staff_member
     if session[:staff_member_id]
       @current_staff_member ||=
@@ -7,4 +9,11 @@ class Staff::Base < ApplicationController
   end
 
   helper_method :current_staff_member
+
+  private def authorize
+    unless current_staff_member
+      flash.alert = "職員としてログインしてください。"
+      redirect_to :staff_login
+    end
+  end
 end

--- a/app/controllers/staff/base.rb
+++ b/app/controllers/staff/base.rb
@@ -1,5 +1,6 @@
 class Staff::Base < ApplicationController
   before_action :authorize
+  before_action :check_account
 
   private def current_staff_member
     if session[:staff_member_id]
@@ -14,6 +15,14 @@ class Staff::Base < ApplicationController
     unless current_staff_member
       flash.alert = "職員としてログインしてください。"
       redirect_to :staff_login
+    end
+  end
+
+  private def check_account
+    if current_staff_member && !current_staff_member.active?
+      session.delete(:staff_member_id)
+      flash.alert = "アカウントが無効になりました。"
+      redirect_to :staff_root
     end
   end
 end

--- a/app/controllers/staff/base.rb
+++ b/app/controllers/staff/base.rb
@@ -1,6 +1,7 @@
 class Staff::Base < ApplicationController
   before_action :authorize
   before_action :check_account
+  before_action :check_timeout
 
   private def current_staff_member
     if session[:staff_member_id]
@@ -23,6 +24,20 @@ class Staff::Base < ApplicationController
       session.delete(:staff_member_id)
       flash.alert = "アカウントが無効になりました。"
       redirect_to :staff_root
+    end
+  end
+
+  TIMEOUT = 60.minutes
+
+  private def check_timeout
+    if current_staff_member
+      if session[:last_access_time] >= TIMEOUT.ago
+        session[:last_access_time] = Time.current
+      else
+        session.delete(:staff_member_id)
+        flash.alert = "セッションがタイムアウトしました。"
+        redirect_to :staff_login
+      end
     end
   end
 end

--- a/app/controllers/staff/base.rb
+++ b/app/controllers/staff/base.rb
@@ -12,6 +12,7 @@ class Staff::Base < ApplicationController
 
   helper_method :current_staff_member
 
+  # アクセス制御
   private def authorize
     unless current_staff_member
       flash.alert = "職員としてログインしてください。"
@@ -19,6 +20,7 @@ class Staff::Base < ApplicationController
     end
   end
 
+  # 強制ログアウト
   private def check_account
     if current_staff_member && !current_staff_member.active?
       session.delete(:staff_member_id)
@@ -27,6 +29,7 @@ class Staff::Base < ApplicationController
     end
   end
 
+  # セッションタイムアウト
   TIMEOUT = 60.minutes
 
   private def check_timeout

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -22,6 +22,7 @@ class Staff::SessionsController < Staff::Base
         render action: "new"
       else
         session[:staff_member_id] = staff_member.id
+        session[:last_access_time] = Time.current
         flash.notice = "ログインしました。"
         redirect_to :staff_root
       end

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -1,4 +1,6 @@
 class Staff::SessionsController < Staff::Base
+  skip_before_action :authorize
+  
   def new
     if current_staff_member
       redirect_to :staff_root

--- a/app/controllers/staff/top_controller.rb
+++ b/app/controllers/staff/top_controller.rb
@@ -1,4 +1,6 @@
 class Staff::TopController < Staff::Base
+  skip_before_action :authorize
+  
   def index
     render action: "index"
   end

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -6,4 +6,8 @@ class Administrator < ApplicationRecord
       self.hashed_password = nil
     end
   end
+
+  def active?
+    !suspended?
+  end
 end

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -6,4 +6,9 @@ class StaffMember < ApplicationRecord
       self.hashed_password = nil
     end
   end
+
+  def active?
+    !suspended? && start_date <= Date.today &&
+      (end_date.nil? || end_date > Date.today)
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,4 +18,5 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 
 begin
   ActiveRecord::Migration.maintain_test_schema!

--- a/spec/requests/admin/staff_members_spec.rb
+++ b/spec/requests/admin/staff_members_spec.rb
@@ -3,6 +3,16 @@ require "rails_helper"
 describe "管理者による職員管理" do
   let(:administrator) { create(:administrator) }
 
+  before do
+    post admin_session_url,
+      params: {
+        admin_login_form: {
+          email: administrator.email,
+          password: "pw"
+        }
+      }
+  end
+
   describe "新規登録" do
     let(:params_hash) { attributes_for(:staff_member) }
 

--- a/spec/requests/admin/staff_members_spec.rb
+++ b/spec/requests/admin/staff_members_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 describe "管理者による職員管理" do
+  context "ログイン前" do
+    include_examples "a protected admin controller", "admin/staff_members"
+  end
+end
+
+describe "管理者による職員管理" do
   let(:administrator) { create(:administrator) }
 
   before do

--- a/spec/requests/admin/staff_members_spec.rb
+++ b/spec/requests/admin/staff_members_spec.rb
@@ -32,6 +32,12 @@ describe "管理者による職員管理" do
       get admin_staff_members_url
       expect(response).to redirect_to(admin_root_url)
     end
+
+    example "セッションタイムアウト" do
+      travel_to Admin::Base::TIMEOUT.from_now.advance(seconds: 1)
+      get admin_staff_members_url
+      expect(response).to redirect_to(admin_login_url)
+    end
   end
 
   describe "新規登録" do

--- a/spec/requests/admin/staff_members_spec.rb
+++ b/spec/requests/admin/staff_members_spec.rb
@@ -19,6 +19,21 @@ describe "管理者による職員管理" do
       }
   end
 
+  describe "情報表示" do
+    let(:staff_member) { create(:staff_member) }
+    
+    example "成功" do
+      get admin_staff_members_url
+      expect(response.status).to eq(200)
+    end
+
+    example "停止フラグがセットされたら強制的にログアウト" do
+      administrator.update_column(:suspended, true)
+      get admin_staff_members_url
+      expect(response).to redirect_to(admin_root_url)
+    end
+  end
+
   describe "新規登録" do
     let(:params_hash) { attributes_for(:staff_member) }
 

--- a/spec/requests/staff/my_account_management_spec.rb
+++ b/spec/requests/staff/my_account_management_spec.rb
@@ -30,8 +30,13 @@ describe "職員による自分のアカウントの管理" do
       get staff_account_url
       expect(response).to redirect_to(staff_root_url)
     end
+
+    example "セッションタイムアウト" do
+      travel_to Staff::Base::TIMEOUT.from_now.advance(seconds: 1)
+      get staff_account_url
+      expect(response).to redirect_to(staff_login_url)
+    end
   end
-  
 
   describe "更新" do
     let(:params_hash) { attributes_for(:staff_member) }

--- a/spec/requests/staff/my_account_management_spec.rb
+++ b/spec/requests/staff/my_account_management_spec.rb
@@ -17,6 +17,22 @@ describe "職員による自分のアカウントの管理" do
       }
   end
 
+  describe "情報表示" do
+    let(:staff_member) { create(:staff_member) }
+    
+    example "成功" do
+      get staff_account_url
+      expect(response.status).to eq(200)
+    end
+
+    example "停止フラグがセットされたら強制的にログアウト" do
+      staff_member.update_column(:suspended, true)
+      get staff_account_url
+      expect(response).to redirect_to(staff_root_url)
+    end
+  end
+  
+
   describe "更新" do
     let(:params_hash) { attributes_for(:staff_member) }
     let(:staff_member) { create(:staff_member) }

--- a/spec/requests/staff/my_account_management_spec.rb
+++ b/spec/requests/staff/my_account_management_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 describe "職員による自分のアカウントの管理" do
+  context "ログイン前" do
+    include_examples "a protected singular staff controller", "staff/accounts"
+  end
+end
+
+describe "職員による自分のアカウントの管理" do
   before do
     post staff_session_url,
       params: {

--- a/spec/support/shared_examples_for_admin_controllers.rb
+++ b/spec/support/shared_examples_for_admin_controllers.rb
@@ -1,0 +1,38 @@
+shared_examples "a protected admin controller" do |controller|
+  let(:args) do
+    {
+      host: Rails.application.config.baukis2[:admin][:host],
+      controller: controller
+    }
+  end
+
+  describe "#index" do
+    example "ログインフォームにリダイレクト" do
+      get url_for(args.merge(action: :index))
+      expect(response).to redirect_to(admin_login_url)
+    end
+  end
+
+  describe "#show" do
+    example "ログインフォームにリダイレクト" do
+      get url_for(args.merge(action: :show, id: 1))
+      expect(response).to redirect_to(admin_login_url)
+    end
+  end
+end
+
+shared_examples "a protected singular admin controller" do |controller|
+  let(:args) do
+    {
+      host: Rails.application.config.baukis2[:admin][:host],
+      controller: controller
+    }
+  end
+
+  describe "#show" do
+    example "ログインフォームにリダイレクト" do
+      get url_for(args.merge(action: :show))
+      expect(response).to redirect_to(admin_login_url)
+    end
+  end
+end

--- a/spec/support/shared_examples_for_staff_controllers.rb
+++ b/spec/support/shared_examples_for_staff_controllers.rb
@@ -1,0 +1,38 @@
+shared_examples "a protected staff controller" do |controller|
+  let(:args) do
+    {
+      host: Rails.application.config.baukis2[:staff][:host],
+      controller: controller
+    }
+  end
+
+  describe "#index" do
+    example "ログインフォームにリダイレクト" do
+      get url_for(args.merge(action: :index))
+      expect(response).to redirect_to(staff_login_url)
+    end
+  end
+
+  describe "#show" do
+    example "ログインフォームにリダイレクト" do
+      get url_for(args.merge(action: :show, id: 1))
+      expect(response).to redirect_to(staff_login_url)
+    end
+  end
+end
+
+shared_examples "a protected singular staff controller" do |controller|
+  let(:args) do
+    {
+      host: Rails.application.config.baukis2[:staff][:host],
+      controller: controller
+    }
+  end
+
+  describe "#show" do
+    example "ログインフォームにリダイレクト" do
+      get url_for(args.merge(action: :show))
+      expect(response).to redirect_to(staff_login_url)
+    end
+  end
+end


### PR DESCRIPTION
- 管理者ページと職員ページに以下をそれぞれ追加
    - アクセス制御の仕組み→`authorize`メソッド
    - 強制ログアウトの仕組み→`check_account`メソッド、`active?`メソッド
    - セッションタイムアウトの仕組み→`check_timeout`メソッド
    - コントローラーで`before_action`を使うとアクション前に呼び出せる

テスト

- 各テストを追加
- 共有エグザンプル `spec/support/shared_*.rb` を、`*_spec.rb`でincludeする
    - `autorize`メソッドのテスト