### PR TITLE
モデル間の関連付け

### DIFF
--- a/app/assets/stylesheets/admin/pagination.scss
+++ b/app/assets/stylesheets/admin/pagination.scss
@@ -1,0 +1,28 @@
+@import "colors";
+@import "dimensions";
+
+nav.pagination {
+  margin: $moderate 0;
+  padding: $moderate 0;
+  display: inline-block;
+  border-top: solid $very_light_gray 1px;
+  border-bottom: solid $very_light_gray 1px;
+  span.page, span.first, span.prev, span.next, span.last {
+    display: inline-block;
+    background-color: $light_gray;
+    padding: $narrow $moderate;
+    a {
+      text-decoration: none;
+    }
+  }
+  span.current {
+    background-color: $dark_gray;
+    color: $light_gray;
+  }
+  span.disabled {
+    color: $gray;
+  }
+  span.gap {
+    background-color: transparent;
+  }
+}

--- a/app/assets/stylesheets/admin/staff_events.scss
+++ b/app/assets/stylesheets/admin/staff_events.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/staff_events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/staff_events_controller.rb
+++ b/app/controllers/admin/staff_events_controller.rb
@@ -1,0 +1,10 @@
+class Admin::StaffEventsController < Admin::Base
+  def index
+    if params[:staff_member_id]
+      @staff_member = StaffMember.find(params[:staff_member_id])
+      @events = @staff_member.events.order(occurred_at: :desc)
+    else
+      @events = StaffEvent.order(occurred_at: :desc)
+    end
+  end
+end

--- a/app/controllers/admin/staff_events_controller.rb
+++ b/app/controllers/admin/staff_events_controller.rb
@@ -2,10 +2,11 @@ class Admin::StaffEventsController < Admin::Base
   def index
     if params[:staff_member_id]
       @staff_member = StaffMember.find(params[:staff_member_id])
-      @events = @staff_member.events.order(occurred_at: :desc)
+      @events = @staff_member.events
     else
-      @events = StaffEvent.order(occurred_at: :desc)
+      @events = StaffEvent
     end
-    @events = StaffEvent.page(params[:page])
+    @events =
+      @events.order(occurred_at: :desc).includes(:member).page(params[:page])
   end
 end

--- a/app/controllers/admin/staff_events_controller.rb
+++ b/app/controllers/admin/staff_events_controller.rb
@@ -6,5 +6,6 @@ class Admin::StaffEventsController < Admin::Base
     else
       @events = StaffEvent.order(occurred_at: :desc)
     end
+    @events = StaffEvent.page(params[:page])
   end
 end

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -18,11 +18,13 @@ class Staff::SessionsController < Staff::Base
     end
     if Staff::Authenticator.new(staff_member).authenticate(@form.password)
       if staff_member.suspended?
+        staff_member.events.create!(type: "rejected")
         flash.now.alert = "アカウントが停止されています。"
         render action: "new"
       else
         session[:staff_member_id] = staff_member.id
         session[:last_access_time] = Time.current
+        staff_member.events.create!(type: "logged_in")
         flash.notice = "ログインしました。"
         redirect_to :staff_root
       end
@@ -37,6 +39,9 @@ class Staff::SessionsController < Staff::Base
   end
 
   def destroy
+    if current_staff_member
+      current_staff_member.events.create!(type: "logged_out")
+    end
     session.delete(:staff_member_id)
     flash.notice = "ログアウトしました。"
     redirect_to :staff_root

--- a/app/models/staff_event.rb
+++ b/app/models/staff_event.rb
@@ -2,5 +2,15 @@ class StaffEvent < ApplicationRecord
   self.inheritance_column = nil
 
   belongs_to :member, class_name: "StaffMember", foreign_key: "staff_member_id"
-  alias.attributes :occurred_at, :created_at
+  alias_attribute :occurred_at, :created_at
+
+  DESCRIPTIONS = {
+    logged_in: "ログイン",
+    logged_out: "ログアウト",
+    rejected: "ログイン拒否"
+  }
+
+  def description
+    DESCRIPTIONS[type.to_sym]
+  end
 end

--- a/app/models/staff_event.rb
+++ b/app/models/staff_event.rb
@@ -1,0 +1,6 @@
+class StaffEvent < ApplicationRecord
+  self.inheritance_column = nil
+
+  belongs_to :member, class_name: "StaffMember", foreign_key: "staff_member_id"
+  alias.attributes :occurred_at, :created_at
+end

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -1,4 +1,6 @@
 class StaffMember < ApplicationRecord
+  has_many :events, class_name: "StaffEvent", dependent: :destroy
+
   def password=(raw_password)
     if raw_password.kind_of?(String)
       self.hashed_password = BCrypt::Password.create(raw_password)

--- a/app/views/admin/staff_events/_event.html.erb
+++ b/app/views/admin/staff_events/_event.html.erb
@@ -1,0 +1,12 @@
+<tr>
+  <% unless @staff_member %>
+  <td>
+    <%= link_to(event.member.family_name + event.member.given_name,
+      [ :admin, event.member, :staff_events ]) %>
+  </td>
+  <% end %>
+  <td><%= event.description %></td>
+  <td class="date">
+    <%= event.occurred_at.strftime("%Y%m%d %H:%M:%S") %>
+  </td>
+</tr>

--- a/app/views/admin/staff_events/index.html.erb
+++ b/app/views/admin/staff_events/index.html.erb
@@ -13,6 +13,8 @@
     <%= link_to "職員一覧", :admin_staff_members %>
   </div>
 
+  <%= paginate @events %>
+
   <table class="listing">
     <tr>
       <% unless @staff_member %><th>氏名</th><% end %>
@@ -27,6 +29,8 @@
       </tr>
     <% end %>
   </table>
+
+  <%= paginate @events %>
 
   <div class="links">
     <%= link_to "職員一覧", :admin_staff_members %>

--- a/app/views/admin/staff_events/index.html.erb
+++ b/app/views/admin/staff_events/index.html.erb
@@ -1,0 +1,34 @@
+<% 
+  if @staff_member
+    full_name = @staff_member.family_name + @staff_member.given_name
+    @title = "#{full_name}さんのログイン・ログアウト記録"
+  else
+    @title = "職員のログイン・ログアウト記録"
+  end
+%>
+<h1><%= @title %></h1>
+
+<div class="table-wrapper">
+  <div class="links">
+    <%= link_to "職員一覧", :admin_staff_members %>
+  </div>
+
+  <table class="listing">
+    <tr>
+      <% unless @staff_member %><th>氏名</th><% end %>
+      <th>種別</th>
+      <th>日時</th>
+    </tr>
+    <%= render partial: "event", collection: @events %>
+    <% if @events.empty? %>
+      <tr>
+        <%= content_tag(:td, "記録がありません",
+          colspan: @staff_member ? 2 : 3, style: "text-align: center") %>
+      </tr>
+    <% end %>
+  </table>
+
+  <div class="links">
+    <%= link_to "職員一覧", :admin_staff_members %>
+  </div>
+</div>

--- a/app/views/admin/staff_members/index.html.erb
+++ b/app/views/admin/staff_members/index.html.erb
@@ -27,6 +27,7 @@
           <%= m.suspended? ? raw("&#x2611;") : raw("&#x2610;") %></td>
         <td class="actions">
           <%= link_to "編集", [ :edit, :admin, m ] %> |
+          <%= link_to "Events", [ :admin, m, :staff_events ] %> |
           <%= link_to "削除", [ :admin, m ], method: :delete,
             data: { confirm: "本当に削除しますか？" } %>
         </td>

--- a/app/views/admin/top/dashboard.html.erb
+++ b/app/views/admin/top/dashboard.html.erb
@@ -3,4 +3,5 @@
 
 <ul class="menu">
   <li><%= link_to "職員管理", :admin_staff_members %></li>
+  <li><%= link_to "職員のログイン・ログアウト管理", :admin_staff_events %></li>
 </ul>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,16 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%=
+    link_to_unless(current_page.first?,
+      t("views.pagination.first").html_safe, url) do |name|
+      content_tag(:span, name, class: "disabled")
+    end
+  %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,16 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%=
+    link_to_unless(current_page.last?,
+      t("views.pagination.last").html_safe, url) do |name|
+      content_tag(:span, name, class: "disabled")
+    end
+  %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,16 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%=
+    link_to_unless(current_page.last?,
+      t("views.pagination.next").html_safe, url) do |name|
+      content_tag(:span, name, class: "disabled")
+    end
+  %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag %>
+    <%= prev_page_tag %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag %>
+      <%= last_page_tag %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,16 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%=
+    link_to_unless(current_page.first?,
+      t("views.pagination.previous").html_safe, url) do |name|
+      content_tag(:span, name, class: "disabled")
+    end
+  %>
+</span>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 30
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/views/paginate.ja.yml
+++ b/config/locales/views/paginate.ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "先頭"
+      last: "末尾"
+      previous: "前"
+      next: "次"
+      truncate: "..."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,10 @@ Rails.application.routes.draw do
       root "top#index"
       get "login" => "sessions#new", as: :login
       resource :session, only: [ :create, :destroy ]
-      resources :staff_members
+      resources :staff_members do
+        resources :staff_events, only: [ :index ]
+      end
+      resources :staff_events, only: [ :index ]
     end
   end
 

--- a/db/migrate/20220624102709_create_staff_events.rb
+++ b/db/migrate/20220624102709_create_staff_events.rb
@@ -1,0 +1,14 @@
+class CreateStaffEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :staff_events do |t|
+
+      t.references :staff_member, null: false, index: false, foreign_key: true
+                                            # 職員レコードへの外部キー
+      t.string :type, null: false           # イベントタイプ
+      t.datetime :created_at, null: false   # 発生時刻
+    end
+
+    add_index :staff_events, :created_at
+    add_index :staff_events, [ :staff_member_id, :created_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_23_113125) do
+ActiveRecord::Schema.define(version: 2022_06_24_102709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,14 @@ ActiveRecord::Schema.define(version: 2022_06_23_113125) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index "lower((email)::text)", name: "index_administrators_on_LOWER_email", unique: true
+  end
+
+  create_table "staff_events", force: :cascade do |t|
+    t.bigint "staff_member_id", null: false
+    t.string "type", null: false
+    t.datetime "created_at", null: false
+    t.index ["created_at"], name: "index_staff_events_on_created_at"
+    t.index ["staff_member_id", "created_at"], name: "index_staff_events_on_staff_member_id_and_created_at"
   end
 
   create_table "staff_members", force: :cascade do |t|
@@ -39,4 +47,6 @@ ActiveRecord::Schema.define(version: 2022_06_23_113125) do
     t.index "lower((email)::text)", name: "index_staff_members_on_LOWER_email", unique: true
     t.index ["family_name_kana", "given_name_kana"], name: "index_staff_members_on_family_name_kana_and_given_name_kana"
   end
+
+  add_foreign_key "staff_events", "staff_members"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-table_names = %w(staff_members administrators)
+table_names = %w(staff_members administrators staff_events)
 
 table_names.each do |table_name|
   path = Rails.root.join("db", "seeds", Rails.env, "#{table_name}.rb")

--- a/db/seeds/development/staff_events.rb
+++ b/db/seeds/development/staff_events.rb
@@ -1,0 +1,17 @@
+staff_members = StaffMember.all
+
+256.times do |n|
+  m = staff_members.sample
+  e = m.events.build
+  if m.active?
+    if n.even?
+      e.type = "logged_in"
+    else
+      e.type = "logged_out"
+    end
+  else
+    e.type = "rejected"
+  end
+  e.occurred_at = (256 - n).hours.ago
+  e.save!
+end

--- a/spec/requests/admin/staff_events_spec.rb
+++ b/spec/requests/admin/staff_events_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::StaffEvents", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
# 職員のログイン・ログアウト情報を閲覧（一覧表示）する機能を実装

- StaffEventモデルを作成
    - 「1」対「多」の関係
        - 「1」側：StaffMemberモデル `has_many`
        - 「多」側：StaffEventモデル `belongs_to` 外部キー:`staff_member_id`
        - 関連付けられているモデルを参照するメソッドが定義される `events`メソッド、`staff`メソッド
- staff_eventsテーブルを作成
- Staff/Sessionsコントローラーに、イベントを記録する処理を追加
- ルーティングの設定（ネストする）
    - 特定の職員のイベント→`/admin/staff_members/:staff_member_id/staff_events`
    - 全職員のイベント→`/admin/staff_events`
- イベント管理へのリンクを追加
- StaffEventsコントローラーを作成 `index`アクションで`@events`を渡す
- ビューを作成
    - `/admin/staff_events/index.html.erb`
    - `/admin/staff_events/_event.html.erb`
- イベントのシードデータを作成
- kaminariでページネーションを実装
- N+1問題の解決とリファクタリング